### PR TITLE
fix type inference such that it also works for dalvik bytecode

### DIFF
--- a/com.ibm.wala.core/src/com/ibm/wala/analysis/typeInference/TypeVariable.java
+++ b/com.ibm.wala.core/src/com/ibm/wala/analysis/typeInference/TypeVariable.java
@@ -20,6 +20,7 @@ import com.ibm.wala.fixpoint.AbstractVariable;
 public class TypeVariable extends AbstractVariable<TypeVariable> {
 
   TypeAbstraction type;
+  private boolean isIntZeroConstant;
 
   public TypeVariable(TypeAbstraction type) {
     if (type == null) {
@@ -44,6 +45,13 @@ public class TypeVariable extends AbstractVariable<TypeVariable> {
     this.type = type;
   }
 
+  public void setIntZeroConstant(boolean newValue) {
+    this.isIntZeroConstant = newValue;
+  }
+
+  public boolean isIntZeroConstant() {
+    return isIntZeroConstant;
+  }
   @Override
   public String toString() {
     return type.toString();


### PR DESCRIPTION
Dalvik bytecode does not distinguish between the integer constant 0 and null.
More specifically, it represents null as 0. This causes the standard
type inference to crash on phi instructions caused by instructions such
as

Object o = (...)?null:new Foo();

The meet operator tries to find the meet between Foo and int here, which
is not expected and therefore crashes.

This fix basically relaxes the meet operator for such situations. That
is, if:
- one of the types to be met is non-primitive and
- one of the type variables whose types are to be met stems from an
  integer zero constant

all integer zero constants are ignored and thus only the non-primitive
types contribute to the meet.
